### PR TITLE
Adds become to backup directory creation

### DIFF
--- a/playbooks/network_backup.yml
+++ b/playbooks/network_backup.yml
@@ -38,6 +38,7 @@
         path: /backup/
         state: directory
       delegate_to: backup-server
+      become: true
       run_once: true
 
     - name: save configuration to backup server


### PR DESCRIPTION
The file module fails when attempting to create /backup during the workshop due to lack of privilege escalation. This resolves the issue.