### PR TITLE
Fix: Handle null value for static_routes in the static.j2 templates

### DIFF
--- a/roles/build_report/templates/static.j2
+++ b/roles/build_report/templates/static.j2
@@ -1,9 +1,10 @@
 <!-- INTERNAL TABLE FOR Static Routes -->
+{% set static_routes = hostvars[network_switch]['ansible_network_resources']['static_routes'] %}
 <div id="accordion">
 <div>
 <h3>Static Routes</h3>
 <div class="net_content">
-{% if hostvars[network_switch]['ansible_network_resources']['static_routes'] is defined and hostvars[network_switch]['ansible_network_resources']['static_routes']|length > 0 %}
+{% if static_routes is not none and static_routes|length > 0 %}
 <table id="subtable">
     <thead>
         <tr>
@@ -16,7 +17,7 @@
         </tr>
     </thead>
     <tbody>
-{% for net_route in hostvars[network_switch]['ansible_network_resources']['static_routes'] %}
+{% for net_route in static_routes %}
 <tr>
     <td>{{ net_route['vrf']|default("N/A") }}</td>
 {% for address_family in net_route.address_families|default([]) %}
@@ -34,7 +35,7 @@
 {% endfor %}
     </tbody>
 </table>
-{% elif hostvars[network_switch]['ansible_network_resources']['static_routes'] is defined and hostvars[network_switch]['ansible_network_resources']['static_routes']|length == 0 %}
+{% elif static_routes is none or static_routes|length == 0 %}
 Static Routes are not configured on this device
 {% else %}
 No Static Route information available

--- a/roles/build_report_container/templates/static.j2
+++ b/roles/build_report_container/templates/static.j2
@@ -1,9 +1,10 @@
 <!-- INTERNAL TABLE FOR Static Routes -->
+{% set static_routes = hostvars[network_switch]['ansible_network_resources']['static_routes'] %}
 <div id="accordion">
 <div>
 <h3>Static Routes</h3>
 <div class="net_content">
-{% if hostvars[network_switch]['ansible_network_resources']['static_routes'] is defined and hostvars[network_switch]['ansible_network_resources']['static_routes']|length > 0 %}
+{% if static_routes is not none and static_routes|length > 0 %}
 <table id="subtable">
     <thead>
         <tr>
@@ -16,7 +17,7 @@
         </tr>
     </thead>
     <tbody>
-{% for net_route in hostvars[network_switch]['ansible_network_resources']['static_routes'] %}
+{% for net_route in static_routes %}
 <tr>
     <td>{{ net_route['vrf']|default("N/A") }}</td>
 {% for address_family in net_route.address_families|default([]) %}
@@ -34,7 +35,7 @@
 {% endfor %}
     </tbody>
 </table>
-{% elif hostvars[network_switch]['ansible_network_resources']['static_routes'] is defined and hostvars[network_switch]['ansible_network_resources']['static_routes']|length == 0 %}
+{% elif static_routes is none or static_routes|length == 0 %}
 Static Routes are not configured on this device
 {% else %}
 No Static Route information available


### PR DESCRIPTION
I recently ran the collection on a Cisco IOS switch that was pretty much in its default state, with no static routes configured. The gathered facts showed "static_routes": null.

In the current setup, the templates are checking if static_routes exists and if it has a length of 0 or more. However, this wasn't playing well when static_routes came back as null, causing the checks to fail.

I introduced a local variable to hold the static routes and tweaked the checks to play nice when static_routes is null. I gave it a whirl on a switch with and without static routes, and everything worked out perfectly.

Thank you for making such a useful collection! 🥳