### PR TITLE
Update static.j2

### DIFF
--- a/roles/build_report_container/templates/static.j2
+++ b/roles/build_report_container/templates/static.j2
@@ -1,5 +1,9 @@
 <!-- INTERNAL TABLE FOR Static Routes -->
-{% set static_routes = hostvars[network_switch]['ansible_network_resources']['static_routes'] %}
+{% if hostvars[network_switch]['ansible_network_resources']['static_routes'] is defined %}
+  {% set static_routes = hostvars[network_switch]['ansible_network_resources']['static_routes'] %}
+{% else %}
+  {% set static_routes = None %}
+{% endif %}
 <div id="accordion">
 <div>
 <h3>Static Routes</h3>


### PR DESCRIPTION
fixing static routes bug identified here:
https://github.com/network-automation/toolkit/issues/47

For some reason.... for Arista EOS and Juniper Junos, they are returning nothing for static_routes all the sudden.... will investigate on latest content collection releases

a simple test confirms this->

```
---
- hosts: arista
  gather_facts: false
  tasks:
    - name: Gather arista eos facts
      arista.eos.eos_facts:
        gather_subset: config
        gather_network_resources: "{{ network_resource | default('!bgp_global,!bgp_address_family') }}"
      register: find_the_routes
      
    - name: gather static routes
      ansible.builtin.debug:
        var: find_the_routes    

    - name: debug hostvars
      debug:
        var: hostvars.rtr4
```

There is no static_routes.... it should just be empty if there are none `{}`

Instead I add a check to my template, but this is not ideal