### PR TITLE
Add interface operational status to network report

### DIFF
--- a/roles/build_report/files/css/main.css
+++ b/roles/build_report/files/css/main.css
@@ -205,3 +205,44 @@ table.net_info {
 p.internal_label {
     color: #000000;
 }
+
+/* Interface operational status styling */
+.status-up {
+    color: #28a745;
+    font-weight: bold;
+    text-shadow: 0 0 2px rgba(40, 167, 69, 0.3);
+}
+
+.status-down {
+    color: #dc3545;
+    font-weight: bold;
+    text-shadow: 0 0 2px rgba(220, 53, 69, 0.3);
+}
+
+.status-unknown {
+    color: #6c757d;
+    font-style: italic;
+    font-weight: normal;
+}
+
+/* Enhanced table responsiveness for additional column */
+#subtable {
+    table-layout: auto;
+    word-wrap: break-word;
+}
+
+#subtable th, #subtable td {
+    min-width: 80px;
+    text-align: center;
+}
+
+#subtable th:first-child, #subtable td:first-child {
+    text-align: left;
+    min-width: 120px;
+}
+
+/* Status column specific styling */
+#subtable th:nth-child(5), #subtable td:nth-child(5) {
+    min-width: 90px;
+    text-align: center;
+}

--- a/roles/build_report/templates/interfaces.j2
+++ b/roles/build_report/templates/interfaces.j2
@@ -1,7 +1,7 @@
 <!-- INTERNAL TABLE FOR INTERFACES -->
 <div id="accordion">
 <div>
-<h3>Interfaces - MTU/Duplex/Speed</h3>
+<h3>Interfaces - MTU/Duplex/Speed/Status</h3>
 <div class="net_content">
 {% if hostvars[network_switch]['ansible_network_resources']['interfaces'] is defined and hostvars[network_switch]['ansible_network_resources']['interfaces']|length > 0  %}
 <table id="subtable">
@@ -10,7 +10,8 @@
             <th>Interface Name</th>
             <th>Description</th>
             <th>Duplex</th>
-            <th>Enabled</th>
+            <th>Admin Status</th>
+            <th>Oper Status</th>
             <th>MTU</th>
             <th>Speed</th>
         </tr>
@@ -21,7 +22,21 @@
             <td>{{interface['name']}}</td>
             <td>{{interface['description']|default("none")}}</td>
             <td>{{interface['duplex']|default("default")}}</td>
-            <td>{{interface['enabled']}}</td>
+            <td>{{interface['enabled']|default("unknown")}}</td>
+            <td>
+              {% set oper_status = interface.get('oper_status', interface.get('line_protocol', interface.get('line_protocol_status', interface.get('admin_state', 'unknown')))) %}
+              {% if oper_status|lower == 'up' %}
+                <span class="status-up">UP</span>
+              {% elif oper_status|lower == 'down' %}
+                <span class="status-down">DOWN</span>
+              {% elif oper_status == true or oper_status|lower == 'enabled' %}
+                <span class="status-up">UP</span>
+              {% elif oper_status == false or oper_status|lower == 'disabled' %}
+                <span class="status-down">DOWN</span>
+              {% else %}
+                <span class="status-unknown">{{ oper_status|upper }}</span>
+              {% endif %}
+            </td>
             <td>{{interface['mtu']|default("default")}}</td>
             <td>{{interface['speed']|default("default")}}</td>
         </tr>


### PR DESCRIPTION
- Enhanced interfaces table to include operational status column
- Added Admin Status and Oper Status columns for better visibility
- Implemented multi-platform operational status detection supporting:
  - Cisco IOS/NXOS: oper_status, line_protocol
  - Juniper Junos: admin_state, oper_status  
  - Arista EOS: line_protocol_status
- Added visual status indicators with color coding:
  - UP: Green with bold text
  - DOWN: Red with bold text  
  - UNKNOWN: Gray with italic text
- Enhanced CSS with responsive table layout for additional column
- Updated section header to reflect new status information

This enhancement provides network operators with immediate visual feedback on both administrative and operational interface states in the network report."